### PR TITLE
Fix orientation validator for multipolygons

### DIFF
--- a/notebooks/00_validation.ipynb
+++ b/notebooks/00_validation.ipynb
@@ -46,6 +46,7 @@
     "from shapely import validation as shapely_validation\n",
     "from shapely.algorithms.cga import signed_area\n",
     "from shapely.geometry.base import BaseGeometry\n",
+    "from shapely.geometry.multipolygon import MultiPolygon\n",
     "from shapely.geometry.polygon import orient\n",
     "\n",
     "logger = logging.getLogger(__name__)"
@@ -137,13 +138,23 @@
     "@patch\n",
     "def check(self: OrientationValidator, geometry: BaseGeometry) -> bool:\n",
     "    \"\"\"Checks if orientation is counter clockwise\"\"\"\n",
-    "    return signed_area(geometry.exterior) >= 0\n",
+    "    if geometry.geom_type == \"Polygon\":\n",
+    "        return signed_area(geometry.exterior) >= 0\n",
+    "    elif geometry.geom_type == \"MultiPolygon\":\n",
+    "        return all([signed_area(g.exterior) >= 0 for g in geometry.geoms])\n",
+    "    else:\n",
+    "        return True\n",
     "\n",
     "\n",
     "@patch\n",
     "def fix(self: OrientationValidator, geometry: BaseGeometry) -> BaseGeometry:\n",
     "    \"\"\"Fixes orientation if orientation is clockwise\"\"\"\n",
-    "    return orient(geometry)"
+    "    if geometry.geom_type == \"Polygon\":\n",
+    "        return orient(geometry)\n",
+    "    elif geometry.geom_type == \"MultiPolygon\":\n",
+    "        return MultiPolygon([orient(g) for g in geometry.geoms])\n",
+    "    else:\n",
+    "        return geometry"
    ]
   },
   {
@@ -309,7 +320,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -19,6 +19,26 @@ def oriented_geometry():
 
 
 @pytest.fixture()
+def misoriented_multipolygon():
+    return multipolygon.MultiPolygon(
+        [
+            polygon.Polygon(([(0, 0), (0, 1), (1, 1), (1, 0)])),
+            polygon.Polygon(([(10, 10), (11, 10), (11, 11), (10, 11)])),
+        ]
+    )
+
+
+@pytest.fixture()
+def oriented_multipolygon():
+    return multipolygon.MultiPolygon(
+        [
+            polygon.Polygon(([(0, 0), (1, 0), (1, 1), (0, 1)])),
+            polygon.Polygon(([(10, 10), (11, 10), (11, 11), (10, 11)])),
+        ]
+    )
+
+
+@pytest.fixture()
 def self_intersecting_geometry():
     return polygon.Polygon([(0, 0), (0, 2), (1, 1), (2, 2), (2, 0), (1, 1), (0, 0)])
 
@@ -144,6 +164,29 @@ def test_orientation_validator_fix_invalid(misoriented_geometry, oriented_geomet
         validation.OrientationValidator()
         .fix(geometry=misoriented_geometry)
         .equals(oriented_geometry)
+    )
+
+
+def test_orientation_validator_invalid_multipolygon(misoriented_multipolygon):
+    assert (
+        validation.OrientationValidator().check(geometry=misoriented_multipolygon)
+        is False
+    )
+
+
+def test_orientation_validator_valid_multipolygon(oriented_multipolygon):
+    assert (
+        validation.OrientationValidator().check(geometry=oriented_multipolygon) is True
+    )
+
+
+def test_orientation_validator_fix_invalid_multipolygon(
+    misoriented_multipolygon, oriented_multipolygon
+):
+    assert (
+        validation.OrientationValidator()
+        .fix(geometry=misoriented_multipolygon)
+        .equals(oriented_multipolygon)
     )
 
 


### PR DESCRIPTION
shapely `orient` and  `signed_area(geom.exterior)` function only works for polygons and breaks for multipolygons. fix is to check and fix each polygon in the multipolygon