### PR TITLE
Run neccessary CI only when certain files changes

### DIFF
--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -2,7 +2,10 @@
 # https://github.com/firebase/firebase-tools
 
 name: Deploy to Firebase Hosting on PR
-"on": pull_request
+"on":
+  pull_request:
+    paths:
+      - "**.ipynb"
 jobs:
   build_and_preview:
     if: "${{ github.event.pull_request.head.repo.full_name == github.repository }}"

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -1,10 +1,10 @@
 name: Check code coverage
 on:
   pull_request:
-  push:
-    branches: [master]
     paths:
       - "**.py"
+  push:
+    branches: [master]
 jobs:
   pytest:
     runs-on: ubuntu-latest

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -3,6 +3,8 @@ on:
   pull_request:
   push:
     branches: [master]
+    paths:
+      - "**.py"
 jobs:
   pytest:
     runs-on: ubuntu-latest


### PR DESCRIPTION
For deploying docs, run only when the notebooks changes
For running tests, run only when python files change

This will only skip CI for PRs. On merge to master, it will still run everything.


Let me know if I missed anything 