### PR TITLE
Fix inadvertent change to ruby/setup-ruby action version

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: ruby/setup-ruby@v3
+      - uses: ruby/setup-ruby@v1
         with:
           ruby-version: "2.7" # Not needed with a .ruby-version file
           bundler-cache: true


### PR DESCRIPTION
Merge to build host errored out due to typo on setup-ruby option