### PR TITLE
Improve setup installation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -164,3 +164,4 @@ _data/
 .vscode/
 notebooks/.last_checked
 test_dir/
+poetry.toml

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,7 @@ If you are reporting a bug, please include:
 2. Install and enable `pre-commit` and `poetry`
 
 ```
-pip install poetry pre-commit
+pip install poetry==1.2.0b3 pre-commit
 pre-commit install
 poetry install
 poetry run pip install pip --upgrade

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ documentation for more details.
 The example below uses `virtualenv` to create a separate environment on Linux or WSL
 using `python3.9`.
 
-This next command will install `libgeos` (required for building pygeos/shapely). See [libgeos documentation](https://libgeos.org/usage/install/) for installation details on other systems.
+This next command will install `libgeos` ( version >=3.8 required for building pygeos/shapely). See [libgeos documentation](https://libgeos.org/usage/install/) for installation details on other systems.
 
 ```
 sudo apt install libgeos-dev  # skip this if you already have GEOS
@@ -84,13 +84,10 @@ git clone https://github.com/thinkingmachines/geowrangler.git
 cd geowrangler
 virtualenv -p /usr/bin/python3.9 .venv
 source .venv/bin/activate
-pip install pre-commit poetry
+pip install pre-commit poetry==1.2.0b3
 pre-commit install
+poetry config --local installer.no-binary pygeos,shapely
 poetry install
-poetry run pip install pip --upgrade
-poetry run pip uninstall pygeos shapely -y
-poetry run pip install pygeos shapely --no-binary shapely --no-binary pygeos
-poetry run pip install -e .
 ```
 
 This completes the installation and setup of a local geowrangler environment.


### PR DESCRIPTION
Use the beta version of poetry to set up `no-binary` parameter. The no binary setup does not work with geos==3.6, there is a missing `make_valid` method after compiling shapely. geo 3.6 is the default for colab so I documented using no-binary  as optional and ignored `poetry.toml`. 
