### PR TITLE
Remove warnings

### DIFF
--- a/geowrangler/datasets/geofabrik.py
+++ b/geowrangler/datasets/geofabrik.py
@@ -2,7 +2,6 @@
 
 __all__ = ["list_geofabrik_regions", "download_geofabrik_region"]
 
-
 # Internal Cell
 import os
 import shutil

--- a/notebooks/05_datasets_geofabrik.ipynb
+++ b/notebooks/05_datasets_geofabrik.ipynb
@@ -12,7 +12,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 2,
    "id": "21f3485c-20cb-44c9-a82d-3cef6a4047cf",
    "metadata": {},
    "outputs": [],
@@ -33,7 +33,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": 3,
    "id": "595e34c0-415a-4ef7-8bb5-4df48d0a0e66",
    "metadata": {},
    "outputs": [],
@@ -50,7 +50,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 51,
+   "execution_count": 4,
    "id": "57334510-4bc1-4a2b-a085-e839f456a8a9",
    "metadata": {},
    "outputs": [],
@@ -63,7 +63,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 61,
+   "execution_count": 5,
    "id": "84a30a6d-c28d-4be2-9325-ac7618d49a31",
    "metadata": {},
    "outputs": [],
@@ -81,25 +81,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 6,
    "id": "0fde158e-98ef-43a1-836b-fed81205d638",
    "metadata": {},
-   "outputs": [
-    {
-     "ename": "NameError",
-     "evalue": "name 'Path' is not defined",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mNameError\u001b[0m                                 Traceback (most recent call last)",
-      "\u001b[0;32m/tmp/ipykernel_17069/1619493446.py\u001b[0m in \u001b[0;36m<cell line: 2>\u001b[0;34m()\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0;31m# export\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 2\u001b[0;31m \u001b[0;32mdef\u001b[0m \u001b[0mdownload_geofabrik_region\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mregion\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0mstr\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mdirectory\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0mstr\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;34m\"data/\"\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;34m->\u001b[0m \u001b[0mPath\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      3\u001b[0m     \u001b[0;34m\"\"\"Download geofabrik region to path\"\"\"\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      4\u001b[0m     \u001b[0;32mif\u001b[0m \u001b[0;32mnot\u001b[0m \u001b[0mos\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mpath\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0misdir\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mdirectory\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      5\u001b[0m         \u001b[0mos\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mmakedirs\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mdirectory\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;31mNameError\u001b[0m: name 'Path' is not defined"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# export\n",
-    "def download_geofabrik_region(region: str, directory: str = \"data/\") -> Path:\n",
+    "def download_geofabrik_region(\n",
+    "    region: str, directory: str = \"data/\", overwrite=False\n",
+    ") -> Path:\n",
     "    \"\"\"Download geofabrik region to path\"\"\"\n",
     "    if not os.path.isdir(directory):\n",
     "        os.makedirs(directory)\n",
@@ -112,7 +102,7 @@
     "    parsed_url = urlparse(url)\n",
     "    filename = Path(os.path.basename(parsed_url.path))\n",
     "    filepath = directory / filename\n",
-    "    if not filepath.exists():\n",
+    "    if not filepath.exists() or overwrite:\n",
     "        response = requests.get(url, stream=True)\n",
     "        with open(filepath, \"wb\") as out_file:\n",
     "            shutil.copyfileobj(response.raw, out_file)\n",
@@ -121,7 +111,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 63,
+   "execution_count": 7,
    "id": "23d8b707-6b41-426b-9135-a422d5a2ad37",
    "metadata": {},
    "outputs": [
@@ -129,7 +119,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Converted 05_data_download.ipynb.\n"
+      "Converted 05_datasets_geofabrik.ipynb.\n"
      ]
     }
    ],
@@ -158,7 +148,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.1"
+   "version": "3.9.11"
   },
   "vscode": {
    "interpreter": {


### PR DESCRIPTION
Closes #138 

for some reasons btw 
` nbdev_update_lib` ignores `geowrangler/datasets/*`
```
(geowrangler-fum3zaCJ-py3.9) ➜  geowrangler git:(fix/geofabrik-docs) ✗ nbdev_update_lib                                          
Converted dhs.py.
Converted vector_zonal_stats.py.
Converted raster_zonal_stats.py.
Converted distance_zonal_stats.py.
Converted grids.py.
Converted area_zonal_stats.py.
Converted validation.py.
(geowrangler-fum3zaCJ-py3.9) ➜  geowrangler git:(fix/geofabrik-docs) ✗ 
``` 