### PR TITLE
Add alternative instructions for conda in dev setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,11 +99,26 @@ poetry install
 ```
 
 This completes the installation and setup of a local geowrangler environment.
+
+If you're using conda, use these set of instructions instead to create a conda env named `geowrangler`:
+```
+git clone https://github.com/thinkingmachines/geowrangler.git
+cd geowrangler
+conda create -n geowrangler python=3.9
+conda activate geowrangler
+pip install pre-commit poetry==1.2.0b3
+pre-commit install
+poetry config --local installer.no-binary pygeos,shapely
+poetry install
+```
+
+
 #### Activating the geowrangler environment
 
-To activate the geowrangler environment, you can `cd <your-local-geowrangler-folder>`
+To activate the geowrangler environment with virtualenv, you can `cd <your-local-geowrangler-folder>`
 and  run `poetry shell` to activate the environment.
 
+If you're using conda, run `conda activate geowrangler`
 
 ### Jupyter Notebook Development
 


### PR DESCRIPTION
In preparation for our internal code camp, just added some instructions for people who use conda as their env manager.
Have tested it locally and have ran all tests successfully.

Let me know if this is ok! 