### PR TITLE
Add default value for aggregations in distance zonal stats

### DIFF
--- a/geowrangler/distance_zonal_stats.py
+++ b/geowrangler/distance_zonal_stats.py
@@ -28,7 +28,7 @@ def create_distance_zonal_stats(
     aoi: gpd.GeoDataFrame,  # Area of interest for which zonal stats are to be computed for
     data: gpd.GeoDataFrame,  # Source gdf of region/areas containing data to compute zonal stats from
     max_distance: float,  # max distance to compute distance for (the larger the slower the join), set to None for no limit
-    aggregations: List[Dict[str, Any]],  # aggregations
+    aggregations: List[Dict[str, Any]] = [],  # aggregations
     distance_col: str = "nearest",  # column name of the distance column, set to None if not wanted in results
 ):
     """Computes zonal stats based on nearest matching data geometry within `max_distance`.

--- a/notebooks/07_distance_zonal_stats.ipynb
+++ b/notebooks/07_distance_zonal_stats.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 82,
    "id": "5a2921e4-4985-4fb3-aa08-c80cb0663a4a",
    "metadata": {
     "tags": []
@@ -14,7 +14,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 83,
    "id": "0bd903f7-54e4-44be-af97-ded1447563a6",
    "metadata": {},
    "outputs": [],
@@ -26,7 +26,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 84,
    "id": "4193ede1-b155-40b0-b90a-1e619fa91fef",
    "metadata": {},
    "outputs": [],
@@ -39,7 +39,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 85,
    "id": "83e17627-2953-424b-add4-1070099a3c64",
    "metadata": {},
    "outputs": [],
@@ -52,7 +52,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 86,
    "id": "8daa0f3a-d80c-4030-bce8-d437cdb313ea",
    "metadata": {},
    "outputs": [],
@@ -66,7 +66,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 87,
    "id": "aaa54b7c-4f2a-4a1b-b46c-3f0e20cd1676",
    "metadata": {},
    "outputs": [],
@@ -94,7 +94,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 88,
    "id": "f438213c-41dc-432f-a54a-48dda949f2ca",
    "metadata": {},
    "outputs": [],
@@ -111,7 +111,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 89,
    "id": "aabdc447-d2ef-45f0-bd1b-a7a0fbd90a14",
    "metadata": {},
    "outputs": [],
@@ -123,7 +123,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 90,
    "id": "8921f67a-31a5-4b59-ac50-2966b8760a6c",
    "metadata": {},
    "outputs": [],
@@ -141,7 +141,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 91,
    "id": "d228a69b-05fb-4dda-a27c-2bd09742414a",
    "metadata": {},
    "outputs": [],
@@ -151,7 +151,7 @@
     "    aoi: gpd.GeoDataFrame,  # Area of interest for which zonal stats are to be computed for\n",
     "    data: gpd.GeoDataFrame,  # Source gdf of region/areas containing data to compute zonal stats from\n",
     "    max_distance: float,  # max distance to compute distance for (the larger the slower the join), set to None for no limit\n",
-    "    aggregations: List[Dict[str, Any]],  # aggregations\n",
+    "    aggregations: List[Dict[str, Any]] = [],  # aggregations\n",
     "    distance_col: str = \"nearest\",  # column name of the distance column, set to None if not wanted in results\n",
     "):\n",
     "    \"\"\"Computes zonal stats based on nearest matching data geometry within `max_distance`.\n",
@@ -221,7 +221,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 92,
    "id": "f92381eb-da51-41e1-b6b0-4fe7480601d4",
    "metadata": {},
    "outputs": [],
@@ -266,7 +266,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 93,
    "id": "29c6aed0-9482-4364-8494-fd4b11c0c689",
    "metadata": {
     "tags": []
@@ -280,7 +280,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 94,
    "id": "a2ad38f2-ef5f-4f2b-b681-8872346a65e8",
    "metadata": {},
    "outputs": [],
@@ -325,7 +325,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 95,
    "id": "b3153f1e-c2e4-4633-a7ab-4df9cf58cb38",
    "metadata": {},
    "outputs": [],
@@ -337,7 +337,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 96,
    "id": "f69269ae-ce43-4871-b6f5-cd56d9385bc3",
    "metadata": {},
    "outputs": [],
@@ -356,7 +356,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 97,
    "id": "6bf3038c-01db-4a23-be8a-966f995f7941",
    "metadata": {},
    "outputs": [
@@ -408,7 +408,7 @@
        "2  POLYGON ((2.000 0.000, 2.000 1.000, 3.000 1.00..."
       ]
      },
-     "execution_count": 16,
+     "execution_count": 97,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -419,7 +419,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 98,
    "id": "c42f2dec-891a-44e5-a8e4-baed7b19e287",
    "metadata": {},
    "outputs": [
@@ -484,7 +484,7 @@
        "2             5.0  "
       ]
      },
-     "execution_count": 17,
+     "execution_count": 98,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -503,7 +503,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 99,
    "id": "e1e355cf-f4cb-4464-99f6-f6ecda87a41f",
    "metadata": {},
    "outputs": [
@@ -647,7 +647,7 @@
        "14  POINT (2.500 7.000)        2300           405.0"
       ]
      },
-     "execution_count": 18,
+     "execution_count": 99,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -658,13 +658,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 100,
    "id": "f784528a-e90f-4544-9b8b-6d6720019b5e",
    "metadata": {},
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAIAAAAD4CAYAAAAkT+5nAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjUuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8qNh9FAAAACXBIWXMAAAsTAAALEwEAmpwYAAAJoklEQVR4nO3dX4xUZxnH8e/TZUvXtkARLtoC3dKQTUijUDd4UdMopNLWpvbC1BLthZqAUROaKA3ExDYmXjQkTY0xRlKqRukfbLHxohWbhto0VuwuoBUI2qIVtiigrKVkYwEfL2ZoYZkd3lnmfc+wz++TbNg95+y8z1l+mTln9n32NXdH4rqo6gKkWgpAcApAcApAcApAcJNyPOiMGTO8t7c3x0PLOA0ODh5295mjt2cJQG9vLwMDAzkeWsbJzN5stF0vAcEpAMEpAMEpAMEpAMGd8y7AzPqAJ0/bNBf4lrs/nKuoZ7YPsXbzHt4aHuGqaT2sWtrHnQuvzjVcJWNWcY6NnDMA7r4HWABgZl3AEPCLXAU9s32INZteY+T4SQCGhkdYs+k1gGw/oNJjVnGOY2n1JWAJ8Ia7N7ynbIe1m/e894M5ZeT4SdZu3pNryOJjVnGOY2k1AHcDjzfaYWbLzWzAzAYOHTo07oLeGh5paXs7lB6zinMcS3IAzOxi4A7g5432u/s6d+939/6ZM896xzHZVdN6WtreDqXHrOIcx9LKM8CtwDZ3/2euYgBWLe2jp7vrjG093V2sWto3Ycas4hzH0srvApYxxtN/O526CCp5hVx6zCrOcSyWMifQzC4F/g7Mdff/nOv4/v5+1y+DOouZDbp7/+jtSc8A7n4M+GDbq5LK6Z3A4BSA4BSA4BSA4BSA4BSA4BSA4BSA4BSA4BSA4BSA4BSA4BSA4BSA4BSA4BSA4BSA4BSA4BSA4JLmBJrZNOAR4HrAgS+6+yu5ilJvYDmp08K/C/zK3T9TbxD5QK6C1BvYYb2BZjYVuAlYD+Du77r7cK6C1BtYVso1wLXAIeBHZrbdzB6p9wmcQb2BnTteMykBmATcAPzA3RcCx4DVow9Sb2DnjtdMSgD2A/vdfWv966eoBSIL9QaWlfIHIv5hZvvMrK/+xyKWALtyFaTewLJSewMXULsNvBjYC3zB3Y+Mdbx6AzvP+fYG7gDO+ma58OmdwOAUgOAUgOAUgOAUgOAUgOAUgOAUgOAUgOAUgOAUgOAUgOAUgOAUgOAUgOAUgOAUgOAUgOAUgOAUgOBSm0P/BhwFTgInGs0ubSc1h5bTyppBn3D3w9kqqVNzaIc1h5am5tCyUgPgwK/NbNDMljc6QM2hnTteM6kB+Ji730Bt7cCvmtlNow9Qc2jnjtdMUgDcfaj+70FqC0cvylWQmkPLSlk+/lLgInc/Wv/8k8C3cxWk5tCyztkcamZzeX+5+EnAY+7+nWbfo+bQzjPu5lB33wt8OEtVUrmOuw2UshSA4BSA4BSA4BSA4BSA4BSA4BSA4BSA4BSA4BSA4BSA4BSA4BSA4BSA4BSA4BSA4BSA4BSA4JJbw8ysCxgAhtz99nwlqTewpFZ6A1cCu4EpmWoB1BvYkb2BZjYL+BS1dYOyUm9gWanXAA8D9wH/G+sA9QZ27njNpCwdeztw0N0Hmx2n3sDOHa+ZlGeAG4E76n8k4glgsZn9LFdB6g0sK6UzaA2wBsDMPg58w90/n6sg9QaWlbRw5HsHvx+ApreB6g3sPOe1cOQp7v4i8GKbapIOoHcCg1MAglMAglMAglMAglMAglMAglMAglMAglMAglMAglMAglMAglMAglMAglMAglMAglMAglMAgktZMeQS4CVgcv34p9z9/pxFqTewnJRJof8FFrv7O2bWDbxsZs+5++9yFKTewA7rDfSad+pfdtc/0ueSt0i9gWWlNod2mdkO4CDwvLtvbXCMegM7dLxmUpeNO+nuC4BZwCIzu77BMeoN7NDxmmnpLsDdh4EtwC1ZqkG9gaWl3AXMBI67+7CZ9QA3Aw/mKki9gWWlrBv4IeAnQBe1Z4yN7t504Uj1Bnae81k38I/AwixVSeX0TmBwCkBwCkBwCkBwCkBwCkBwCkBwCkBwCkBwCkBwCkBwCkBwCkBwCkBwCkBwCkBwCkBwCkBwCkBwKWsGzTazLWa2y8x2mtnKEoVJGSm9gSeAr7v7NjO7HBg0s+fdfVfm2qSAlN7AA+6+rf75UWqLR5afwC5ZtHQNYGa91KaIZ+sNlLKSA2BmlwFPA/e6+9uj97erN1DKSu0O7qb2n7/B3TflLUlKSrkLMGA9sNvdH8pfkpSUunLoPdRWDN1R/7gtc11SSEpv4MuAFahFKqB3AoNTAIJTAIJTAIJTAIJTAIJTAIJTAIJTAIJTAIJTAIJTAIJTAIJTAIJTAIJTAIJTAIJTAIJTAIJTAIJLmRb+qJkdNLM/lShIykp5BvgxGReJkmqlNIe+BPy7QC1SgZT28CRmthxYDjBnzpwzd06fDkeOtGuoc5q+Go5cUmw4AOzBf+Ej04uNN23qCH/9w/ca7ps8ZQo9V3w56XHaFgB3Xwesg9qqYWfsPHIExlqd7Ng34cA17SqjNtyGFfjnfth4uEmPceD3X2nreADzRqbzlyc3Ntw3Zf5P2ffbB9o6Xv+Kj/DG5iUN91239AV6rkh7HN0FBKcABJdyG/g48ArQZ2b7zexL+cuSUlKaQ5eVKESqoZeA4BSA4BSA4BSA4BSA4BSA4BSA4BSA4BSA4BSA4BSA4BSA4BSA4BSA4BSA4BSA4BSA4BSA4BSA4FLXDLrFzPaY2etmtjp3UVJOyqzgLuD7wK3AfGCZmc3PXZiUkfIMsAh43d33uvu7wBPAp/OWJaWktIZdDew77ev9wEdHH9S0N7B2wLgKHJcHwDasaHLAbzIMehfzPnvXmPvabdrUEa5b+kLDfZOnTEl+nDK9gWP1BWZSdrS6+0sP2APcd96PkvISMATMPu3rWfVtMgGkBOBVYJ6ZXWtmFwN3A7/MW5aUktIadsLMvgZsBrqAR919Z/bKpIikawB3fxZ4NnMtUgG9ExicAhCcAhCcAhCceYY3aczsEPDmaZtmAIfbPlBn6fRzvMbdZ47emCUAZw1iNuDu/dkHqtCFeo56CQhOAQiuVADWFRqnShfkORa5BpDOpZeA4BSA4LIHYCJPKDWz2Wa2xcx2mdlOM1tZdU2tynoNUJ9Q+mfgZmpTyV4Flrn7rmyDFmRmVwJXuvs2M7scGATuvJDOL/czwISeUOruB9x9W/3zo8BuanMoLxi5A9BoQukF9QNKZWa9wEJga8WltEQXgW1gZpcBTwP3uvvbVdfTitwBmPATSs2sm9p//gZ331R1Pa3KHYAJPaHUzAxYD+x294eqrmc8sgbA3U8ApyaU7gY2TrAJpTcC9wCLzWxH/eO2qotqhd4KDk4XgcEpAMEpAMEpAMEpAMEpAMEpAMH9H+xOSR5Mchz2AAAAAElFTkSuQmCC\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAIAAAAD4CAYAAAAkT+5nAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjUuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8qNh9FAAAACXBIWXMAAAsTAAALEwEAmpwYAAAJoklEQVR4nO3dX4xUZxnH8e/TZUvXtkARLtoC3dKQTUijUDd4UdMopNLWpvbC1BLthZqAUROaKA3ExDYmXjQkTY0xRlKqRukfbLHxohWbhto0VuwuoBUI2qIVtiigrKVkYwEfL2ZoYZkd3lnmfc+wz++TbNg95+y8z1l+mTln9n32NXdH4rqo6gKkWgpAcApAcApAcApAcJNyPOiMGTO8t7c3x0PLOA0ODh5295mjt2cJQG9vLwMDAzkeWsbJzN5stF0vAcEpAMEpAMEpAMEpAMGd8y7AzPqAJ0/bNBf4lrs/nKuoZ7YPsXbzHt4aHuGqaT2sWtrHnQuvzjVcJWNWcY6NnDMA7r4HWABgZl3AEPCLXAU9s32INZteY+T4SQCGhkdYs+k1gGw/oNJjVnGOY2n1JWAJ8Ia7N7ynbIe1m/e894M5ZeT4SdZu3pNryOJjVnGOY2k1AHcDjzfaYWbLzWzAzAYOHTo07oLeGh5paXs7lB6zinMcS3IAzOxi4A7g5432u/s6d+939/6ZM896xzHZVdN6WtreDqXHrOIcx9LKM8CtwDZ3/2euYgBWLe2jp7vrjG093V2sWto3Ycas4hzH0srvApYxxtN/O526CCp5hVx6zCrOcSyWMifQzC4F/g7Mdff/nOv4/v5+1y+DOouZDbp7/+jtSc8A7n4M+GDbq5LK6Z3A4BSA4BSA4BSA4BSA4BSA4BSA4BSA4BSA4BSA4BSA4BSA4BSA4BSA4BSA4BSA4BSA4BSA4BSA4JLmBJrZNOAR4HrAgS+6+yu5ilJvYDmp08K/C/zK3T9TbxD5QK6C1BvYYb2BZjYVuAlYD+Du77r7cK6C1BtYVso1wLXAIeBHZrbdzB6p9wmcQb2BnTteMykBmATcAPzA3RcCx4DVow9Sb2DnjtdMSgD2A/vdfWv966eoBSIL9QaWlfIHIv5hZvvMrK/+xyKWALtyFaTewLJSewMXULsNvBjYC3zB3Y+Mdbx6AzvP+fYG7gDO+ma58OmdwOAUgOAUgOAUgOAUgOAUgOAUgOAUgOAUgOAUgOAUgOAUgOAUgOAUgOAUgOAUgOAUgOAUgOAUgOAUgOBSm0P/BhwFTgInGs0ubSc1h5bTyppBn3D3w9kqqVNzaIc1h5am5tCyUgPgwK/NbNDMljc6QM2hnTteM6kB+Ji730Bt7cCvmtlNow9Qc2jnjtdMUgDcfaj+70FqC0cvylWQmkPLSlk+/lLgInc/Wv/8k8C3cxWk5tCyztkcamZzeX+5+EnAY+7+nWbfo+bQzjPu5lB33wt8OEtVUrmOuw2UshSA4BSA4BSA4BSA4BSA4BSA4BSA4BSA4BSA4BSA4BSA4BSA4BSA4BSA4BSA4BSA4BSA4BSA4JJbw8ysCxgAhtz99nwlqTewpFZ6A1cCu4EpmWoB1BvYkb2BZjYL+BS1dYOyUm9gWanXAA8D9wH/G+sA9QZ27njNpCwdeztw0N0Hmx2n3sDOHa+ZlGeAG4E76n8k4glgsZn9LFdB6g0sK6UzaA2wBsDMPg58w90/n6sg9QaWlbRw5HsHvx+ApreB6g3sPOe1cOQp7v4i8GKbapIOoHcCg1MAglMAglMAglMAglMAglMAglMAglMAglMAglMAglMAglMAglMAglMAglMAglMAglMAglMAgktZMeQS4CVgcv34p9z9/pxFqTewnJRJof8FFrv7O2bWDbxsZs+5++9yFKTewA7rDfSad+pfdtc/0ueSt0i9gWWlNod2mdkO4CDwvLtvbXCMegM7dLxmUpeNO+nuC4BZwCIzu77BMeoN7NDxmmnpLsDdh4EtwC1ZqkG9gaWl3AXMBI67+7CZ9QA3Aw/mKki9gWWlrBv4IeAnQBe1Z4yN7t504Uj1Bnae81k38I/AwixVSeX0TmBwCkBwCkBwCkBwCkBwCkBwCkBwCkBwCkBwCkBwCkBwCkBwCkBwCkBwCkBwCkBwCkBwCkBwCkBwKWsGzTazLWa2y8x2mtnKEoVJGSm9gSeAr7v7NjO7HBg0s+fdfVfm2qSAlN7AA+6+rf75UWqLR5afwC5ZtHQNYGa91KaIZ+sNlLKSA2BmlwFPA/e6+9uj97erN1DKSu0O7qb2n7/B3TflLUlKSrkLMGA9sNvdH8pfkpSUunLoPdRWDN1R/7gtc11SSEpv4MuAFahFKqB3AoNTAIJTAIJTAIJTAIJTAIJTAIJTAIJTAIJTAIJTAIJTAIJTAIJTAIJTAIJTAIJTAIJTAIJTAIJTAIJLmRb+qJkdNLM/lShIykp5BvgxGReJkmqlNIe+BPy7QC1SgZT28CRmthxYDjBnzpwzd06fDkeOtGuoc5q+Go5cUmw4AOzBf+Ej04uNN23qCH/9w/ca7ps8ZQo9V3w56XHaFgB3Xwesg9qqYWfsPHIExlqd7Ng34cA17SqjNtyGFfjnfth4uEmPceD3X2nreADzRqbzlyc3Ntw3Zf5P2ffbB9o6Xv+Kj/DG5iUN91239AV6rkh7HN0FBKcABJdyG/g48ArQZ2b7zexL+cuSUlKaQ5eVKESqoZeA4BSA4BSA4BSA4BSA4BSA4BSA4BSA4BSA4BSA4BSA4BSA4BSA4BSA4BSA4BSA4BSA4BSA4BSA4FLXDLrFzPaY2etmtjp3UVJOyqzgLuD7wK3AfGCZmc3PXZiUkfIMsAh43d33uvu7wBPAp/OWJaWktIZdDew77ev9wEdHH9S0N7B2wLgKHJcHwDasaHLAbzIMehfzPnvXmPvabdrUEa5b+kLDfZOnTEl+nDK9gWP1BWZSdrS6+0sP2APcd96PkvISMATMPu3rWfVtMgGkBOBVYJ6ZXWtmFwN3A7/MW5aUktIadsLMvgZsBrqAR919Z/bKpIikawB3fxZ4NnMtUgG9ExicAhCcAhCcAhCceYY3aczsEPDmaZtmAIfbPlBn6fRzvMbdZ47emCUAZw1iNuDu/dkHqtCFeo56CQhOAQiuVADWFRqnShfkORa5BpDOpZeA4BSA4LIHYCJPKDWz2Wa2xcx2mdlOM1tZdU2tynoNUJ9Q+mfgZmpTyV4Flrn7rmyDFmRmVwJXuvs2M7scGATuvJDOL/czwISeUOruB9x9W/3zo8BuanMoLxi5A9BoQukF9QNKZWa9wEJga8WltEQXgW1gZpcBTwP3uvvbVdfTitwBmPATSs2sm9p//gZ331R1Pa3KHYAJPaHUzAxYD+x294eqrmc8sgbA3U8ApyaU7gY2TrAJpTcC9wCLzWxH/eO2qotqhd4KDk4XgcEpAMEpAMEpAMEpAMEpAMEpAMH9H+xOSR5Mchz2AAAAAElFTkSuQmCC",
       "text/plain": [
        "<Figure size 432x288 with 1 Axes>"
       ]
@@ -696,7 +696,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 101,
    "id": "b00ea090-f2a6-4da4-9317-34b5112a4f01",
    "metadata": {
     "tags": []
@@ -706,8 +706,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 20.4 ms, sys: 10.1 ms, total: 30.5 ms\n",
-      "Wall time: 26.2 ms\n"
+      "CPU times: user 32.1 ms, sys: 11 ms, total: 43.1 ms\n",
+      "Wall time: 36 ms\n"
      ]
     }
    ],
@@ -727,7 +727,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 102,
    "id": "9045bac2-8114-4bde-a0a3-9a15e7f2cec8",
    "metadata": {},
    "outputs": [
@@ -800,7 +800,7 @@
        "2             300                  5.0      2.0  "
       ]
      },
-     "execution_count": 21,
+     "execution_count": 102,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -811,7 +811,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 103,
    "id": "c777b2eb-f2ce-4496-9de9-6dcc7a21ae10",
    "metadata": {
     "tags": []
@@ -821,7 +821,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 37.9 ms, sys: 0 ns, total: 37.9 ms\n",
+      "CPU times: user 38.5 ms, sys: 0 ns, total: 38.5 ms\n",
       "Wall time: 35 ms\n"
      ]
     }
@@ -842,7 +842,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 104,
    "id": "e6d18a51-a7da-4359-a88c-3cb38cf18599",
    "metadata": {},
    "outputs": [
@@ -915,7 +915,7 @@
        "2             500                  7.5      0.0  "
       ]
      },
-     "execution_count": 23,
+     "execution_count": 104,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -927,7 +927,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3.9.13 ('geowrangler')",
    "language": "python",
    "name": "python3"
   },
@@ -941,7 +941,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.12"
+   "version": "3.9.13"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "b410fe139438bed34f05f80b48d0d7d7dae213c9b4c838055b90e22a668b72ad"
+   }
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Added blank  default value for aggregations in distance zonal stats. With the default value, only the 'distance to the nearest' column is added to the output. Closes #120 