### PR TITLE
Pin black version for nbqa

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,8 +13,9 @@ repos:
     hooks:
       - id: isort
   - repo: https://github.com/nbQA-dev/nbQA
-    rev: 1.3.1
+    rev: 1.6.3
     hooks:
       - id: nbqa-black
+        additional_dependencies: [black==22.3.0]
       - id: nbqa-flake8
       - id: nbqa-isort


### PR DESCRIPTION
Pin black version of nbqa to be reproducible and consistent. Local installation of pre-commit nbqa was using a different version of black in ci/cd cause of local caching. Local would using the latest black version at the time of running `pre-commit install` while  ci/cd will use the latest version of black. It ended up cause pre-commit ci/cd to fail while local to passes. Pinning the black version solves this.  