### PR TITLE
fix:Reduce image size geowrangler logo

### DIFF
--- a/images/Geowrangler.svg
+++ b/images/Geowrangler.svg
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0.00 0.00 1448.00 1448.00" width="3334.00" height="3334.00">
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0.00 0.00 1448.00 1448.00" width="245.00" height="245.00">
 <g stroke-width="2.00" fill="none" stroke-linecap="butt">
 <path stroke="#807530" vector-effect="non-scaling-stroke" d="
   M 584.76 114.39

--- a/notebooks/images/Geowrangler.svg
+++ b/notebooks/images/Geowrangler.svg
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0.00 0.00 1448.00 1448.00" width="3334.00" height="3334.00">
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0.00 0.00 1448.00 1448.00" width="245.00" height="245.00">
 <g stroke-width="2.00" fill="none" stroke-linecap="butt">
 <path stroke="#807530" vector-effect="non-scaling-stroke" d="
   M 584.76 114.39


### PR DESCRIPTION
* Reduce geowrangler logo image size from 3334 x 3334 px to 245 x 245 