### PR TITLE
update nbdev cli commands to use the nbdev 2.0 versions instead of nb…

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,7 +59,7 @@ poetry run pytest --cov --cov-config=.coveragerc --cov-fail-under=80 -n auto
 Once the necessary changes are made, run the following to generate the python code.
 
 ```
-poetry run nbdev_build_lib
+poetry run nbdev_export
 poetry run pre-commit run -a
 poetry run pre-commit run -a
 ```

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -46,7 +46,7 @@ cd geowrangler
 virtualenv -p /usr/bin/python3.9 .venv
 source .venv/bin/activate
 pip install -e ".[dev]"
-nbdev_install_git_hooks
+nbdev_install_hooks
 ```
 
 You're all set! [Run the tests](#running-tests) to make sure everything was installed properly.
@@ -68,7 +68,7 @@ Then run the following to install the pre-commits and python libs.
 ```
 cd geowrangler # cd into your geowrangler local directory
 pip install -e ".[dev]"
-nbdev_install_git_hooks
+nbdev_install_hooks
 
 ```
 

--- a/mkdocs/docs/README.md
+++ b/mkdocs/docs/README.md
@@ -146,7 +146,7 @@ poetry run jupyter lab
 
 To generate and view the documentation site on your local machine, the quickest way is to setup [Docker](https://docs.docker.com/get-started/). The following assumes that you have setup docker on your system.
 ```
-poetry run nbdev_build_docs --mk_readme False --force_all True
+poetry run nbdev_docs --mk_readme False --force_all True
 docker-compose up jekyll
 ```
 
@@ -160,7 +160,7 @@ To generate the docs, run the following
 
 ```
 
-poetry run nbdev_build_docs -mk_readme False --force_all True
+poetry run nbdev_docs -mk_readme False --force_all True
 cd docs && bundle i && cd ..
 
 ```


### PR DESCRIPTION
This PR updates the nbdev cli commands in `README`, `CONTRIBUTING`, and `DEVELOPMENT` from the nbdev 1.0 version to the nbdev 2.0 version