### PR TITLE
pyproject toml entry only includes the main `geowrangler` package in its like of packages 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dev = ['nbdev', 'jupyterlab', 'matplotlib', 'nbdime', 'ipytest', 'branca', 'foli
 version = {attr = "geowrangler.__version__"}
 
 [tool.setuptools.packages.find]
-include = ["geowrangler"]
+include = ["geowrangler*"]
 
 [tool.nbdev]
 nbs_path = 'notebooks'


### PR DESCRIPTION
By changing the entry in `pyproject.toml` to use `geowrangler*` -- it now correctly generates the subpackages within geowrangler.